### PR TITLE
[feat] #46 운영 환경 변경

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -7,31 +7,27 @@ on:
       - 'releases/**'
 
 env:
-  AWS_REGION: ap-northeast-2
-  AWS_S3_BUCKET: gitactionbucket
-  AWS_CODE_DEPLOY_APPLICATION: cicd-test-cd
-  AWS_CODE_DEPLOY_GROUP: cicd-test-cd-group
   APPLICATION: ${{ secrets.APPLICATION }}
   WORKING_DIRECTORY: ./
 
 jobs:
   build-with-gradle:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - name: JDK 17 설치
-        uses: actions/setup-java@v3
+      - name: JDK 17 설정
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'corretto'
 
-      - name: 환경변수 설정
+      - name: applications.yml 환경변수 설정
         run: |
           echo "${{env.APPLICATION}}" > ./src/main/resources/application.yml
 
-      - name: gradlew에 실행 권한 부여
+      - name: gradlew 실행 권한 부여
         run: chmod +x gradlew
         working-directory: ${{ env.WORKING_DIRECTORY }}
 
@@ -57,7 +53,5 @@ jobs:
           key: ${{ secrets.REMOTE_IDENTITYFILE }}
           port: ${{ secrets.REMOTE_PORT }}
           script: |
-            cd server
-            docker compose -f docker-compose.yml down leets-be
-            docker compose -f docker-compose.yml pull leets-be
-            docker compose -f docker-compose.yml up -d leets-be
+            cd docker-compose
+            sudo ./deploy.sh

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@
 # 기술스택
 + 프레임워크 : SpringBoot 3.0.9
 + 언어 : Java 17
-+ 데이터베이스 : MariaDB
++ 데이터베이스 : MySQL
 + 인프라 : AWS EC2
 + CI/CD: GitHub Actions
 
 <br>
 
 # Environment
-```java
+```
 # Cors 관련 환경변수
 CORS_ORIGIN_DEVELOPMENT=
 CORS_ORIGIN_PRODUCTION=

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
-    runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+    runtimeOnly 'com.mysql:mysql-connector-j'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,14 +5,14 @@ spring:
   profiles:
     default: dev
   datasource:
-    driver-class-name: org.mariadb.jdbc.Driver
+    driver-class-name: com.mysql.cj.jdbc.Driver
     username: ${DATABASE_USERNAME}
     url: ${DATABASE_URL}
     password: ${DATABASE_PASSWORD}
   jpa:
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.MariaDBDialect
+        dialect: org.hibernate.dialect.MySQLDialect
         format_sql: true
         use_sql_comments: true
         show_sql: true


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?
- 테스트 환경과 일치하지 않는 운영환경 DB를 MySQL로 변경하였습니다.
- 기존 인스턴스가 지원 중단됨에 따라, Ubuntu 24.04 LTS로 변경하였습니다.
- ZeroSSL 정책이 변경됨에 따라, SSL 인증 방식을 Nginx+CertBot을 Docker Compose 방식으로 변경하였습니다.
<br>

## 2. 어떤 위험이나 장애를 발견했나요?
- 현재 도메인 DNS가 인스턴스랑 매핑이 되지 않은 상황입니다. 따라서 `nip.io`를 통해 임시로 인증을 진행해둔 상황입니다.
<br>

## 3. 관련 스크린샷을 첨부해주세요.
- 없습니다.
<br>

## 4. 완료 사항
- 인스턴스 환경 변경
- DB 변경
- Nginx를 통한 SSL 인증
<br>

## 5. 추가 사항